### PR TITLE
Added support for redis pipelining on command publishing

### DIFF
--- a/src/main/java/cloud/orbit/actors/cluster/RedisClusterConfig.java
+++ b/src/main/java/cloud/orbit/actors/cluster/RedisClusterConfig.java
@@ -65,7 +65,8 @@ public class RedisClusterConfig
     private Boolean shareEventLoop = false;
     private List<RedisPipelineStep> pipelineSteps = RedisBasicPipeline.defaultPipeline();
     private ExecutorService coreExecutorService = ForkJoinPool.commonPool();
-
+    private Long redisPipelineFlushIntervalMillis = 500L;
+    private Integer redisPipelineFlushCommandCount = 16;
 
     public List<String> getActorDirectoryUris()
     {
@@ -309,5 +310,25 @@ public class RedisClusterConfig
     public void setMessagingHealthcheckInterval(Integer messagingHealthcheckInterval)
     {
         this.messagingHealthcheckInterval = messagingHealthcheckInterval;
+    }
+
+    public Long getRedisPipelineFlushIntervalMillis()
+    {
+        return redisPipelineFlushIntervalMillis;
+    }
+
+    public void setRedisPipelineFlushIntervalMillis(final Long redisPipelineFlushIntervalMillis)
+    {
+        this.redisPipelineFlushIntervalMillis = redisPipelineFlushIntervalMillis;
+    }
+
+    public Integer getRedisPipelineFlushCommandCount()
+    {
+        return redisPipelineFlushCommandCount;
+    }
+
+    public void setRedisPipelineFlushCommandCount(final Integer redisPipelineFlushCommandCount)
+    {
+        this.redisPipelineFlushCommandCount = redisPipelineFlushCommandCount;
     }
 }

--- a/src/main/java/cloud/orbit/actors/cluster/impl/RedisConnectionManager.java
+++ b/src/main/java/cloud/orbit/actors/cluster/impl/RedisConnectionManager.java
@@ -99,7 +99,7 @@ public class RedisConnectionManager
         for (final String uri : messagingMasters)
         {
             logger.info("Connecting to Redis messaging node at '{}'...", uri);
-            messagingClients.add(createLettuceOrbitClient(uri));
+            messagingClients.add(createLettuceOrbitClient(uri, redisClusterConfig.getRedisPipelineFlushIntervalMillis(), redisClusterConfig.getRedisPipelineFlushCommandCount()));
 
         }
     }
@@ -170,9 +170,9 @@ public class RedisConnectionManager
     }
 
 
-    private LettuceOrbitClient createLettuceOrbitClient(final String uri)
+    private LettuceOrbitClient createLettuceOrbitClient(final String uri, final long pipelineFlushIntervalMillis, final int pipelineFlushCount)
     {
-        return new LettuceOrbitClient(this.resolveUri(uri));
+        return new LettuceOrbitClient(this.resolveUri(uri), pipelineFlushIntervalMillis, pipelineFlushCount);
     }
 
     private RedissonOrbitClient createRedissonOrbitClient(final String uri, final Boolean useJavaSerializer)

--- a/src/main/java/cloud/orbit/actors/cluster/impl/lettuce/LettuceOrbitClient.java
+++ b/src/main/java/cloud/orbit/actors/cluster/impl/lettuce/LettuceOrbitClient.java
@@ -38,6 +38,10 @@ import io.lettuce.core.pubsub.StatefulRedisPubSubConnection;
 import io.lettuce.core.pubsub.api.async.RedisPubSubAsyncCommands;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class LettuceOrbitClient
 {
@@ -49,15 +53,46 @@ public class LettuceOrbitClient
     private final StatefulRedisPubSubConnection<String, Object> redisPublishingConnection;
     private final RedisPubSubAsyncCommands<String, Object> redisPublishingAsyncCommands;
 
-    public LettuceOrbitClient(final String resolvedUri)
+    private final AtomicInteger commandCounter = new AtomicInteger();
+    private final int pipelineFlushCount;
+
+    private ScheduledExecutorService executor;
+
+    public LettuceOrbitClient(final String resolvedUri, long pipelineFlushIntervalMillis, int pipelineFlushCount)
     {
+        this.pipelineFlushCount = pipelineFlushCount;
+        boolean autoFlush = pipelineFlushIntervalMillis < 1;
+
         this.redisClient = RedisClient.create(resolvedUri);
 
         this.redisSubscribingConnection = this.redisClient.connectPubSub(new FstSerializedObjectCodec());
         this.redisSubscribingAsyncCommands = this.redisSubscribingConnection.async();
+        this.redisSubscribingAsyncCommands.setAutoFlushCommands(true); // No redis pipelining on subscriptions
 
         this.redisPublishingConnection = this.redisClient.connectPubSub(new FstSerializedObjectCodec());
         this.redisPublishingAsyncCommands = this.redisPublishingConnection.async();
+        this.redisPublishingAsyncCommands.setAutoFlushCommands(autoFlush);
+
+        setupExecutor(pipelineFlushIntervalMillis);
+    }
+
+    /*
+        Single thread executor, to clean up(flush) redis pipeline in case of low command activity
+     */
+    private void setupExecutor(long pipelineFlushIntervalMillis) {
+        if (pipelineFlushIntervalMillis < 1) {
+            return;
+        }
+        this.executor = Executors.newSingleThreadScheduledExecutor();
+        Runnable task = () -> {
+            try {
+                redisPublishingAsyncCommands.flushCommands();
+            } catch (Exception e) {
+                logger.error("Error flushing commands", e);
+            }
+        };
+
+        executor.scheduleAtFixedRate(task, pipelineFlushIntervalMillis, pipelineFlushIntervalMillis, TimeUnit.MILLISECONDS);
     }
 
     public CompletableFuture<Void> subscribe(final String channelId, final RedisPubSubListener<String, Object> messageListener)
@@ -65,8 +100,7 @@ public class LettuceOrbitClient
         if (this.redisSubscribingConnection.isOpen())
         {
             this.redisSubscribingConnection.addListener(messageListener);
-            final RedisFuture<Void> subscribeResult = this.redisSubscribingAsyncCommands.subscribe(channelId);
-            return (CompletableFuture)subscribeResult;
+            return this.redisSubscribingAsyncCommands.subscribe(channelId).toCompletableFuture();
         }
         else
         {
@@ -79,8 +113,13 @@ public class LettuceOrbitClient
 
     public CompletableFuture<Long> publish(final String channelId, final Object redisMsg)
     {
-        if (this.redisPublishingConnection.isOpen()) {
-            return (CompletableFuture)this.redisPublishingAsyncCommands.publish(channelId, redisMsg);
+        if (this.redisPublishingConnection.isOpen())
+        {
+            return this.redisPublishingAsyncCommands.publish(channelId, redisMsg).toCompletableFuture()
+                    .thenApply(r -> {
+                        this.checkFlush();
+                        return r;
+                    });
         }
         else
         {
@@ -89,6 +128,19 @@ public class LettuceOrbitClient
             result.completeExceptionally(new IllegalStateException("Error publishing to channel..."));
             return result;
         }
+    }
+
+    private void checkFlush()
+    {
+        if (needsFlush())
+        {
+            redisPublishingAsyncCommands.flushCommands();
+        }
+    }
+
+    private boolean needsFlush()
+    {
+        return pipelineFlushCount > 0 && commandCounter.updateAndGet(n -> (n > pipelineFlushCount) ? 0 : n + 1 ) == 0;
     }
 
     public boolean isConnected()


### PR DESCRIPTION
Added support for redis pipelining on command publishing which can easily be invoked thousands of times per second.  Adding redis pipelining can improve throughput 4-10X.