### PR TITLE
Better Clustering Algorithm

### DIFF
--- a/src/main/java/cloud/orbit/actors/cluster/RedisClusterBuilder.java
+++ b/src/main/java/cloud/orbit/actors/cluster/RedisClusterBuilder.java
@@ -29,6 +29,7 @@
 package cloud.orbit.actors.cluster;
 
 import cloud.orbit.actors.cluster.pipeline.RedisPipelineStep;
+import cloud.orbit.actors.extensions.ActorClassFinder;
 
 import java.util.Arrays;
 import java.util.List;
@@ -45,6 +46,10 @@ public class RedisClusterBuilder
         redisClusterConfig = new RedisClusterConfig();
     }
 
+    public RedisClusterBuilder actorClassFinder(final ActorClassFinder actorClassFinder) {
+        redisClusterConfig.setActorClassFinder(actorClassFinder);
+        return this;
+    }
 
     public RedisClusterBuilder nodeDirectoryUri(final String nodeDirectoryUri) {
         redisClusterConfig.setNodeDirectoryUris(Arrays.asList(nodeDirectoryUri));
@@ -208,6 +213,29 @@ public class RedisClusterBuilder
         redisClusterConfig.setUseClusterForDirectoryNodes(useClustering);
         return this;
     }
+
+    public RedisClusterBuilder minNodesInCluster(final Integer minNodesInCluster) {
+        redisClusterConfig.setMinNodesInCluster(minNodesInCluster);
+        return this;
+    }
+
+    public RedisClusterBuilder foreignNodeDeathTimeoutMillis(final int foreignNodeDeathTimeoutMillis) {
+        redisClusterConfig.setForeignNodeDeathTimeoutMillis(foreignNodeDeathTimeoutMillis);
+        return this;
+    }
+
+    /** Note: valid configurations require that localNodeDeathTimeoutMillis << foreignNodeDeathTimeoutMillis, to avoid
+     * scenarios where a node believes that another node has died before that other node figures it out for itself. */
+    public RedisClusterBuilder localNodeDeathTimeoutMillis(final int localNodeDeathTimeoutMillis) {
+        redisClusterConfig.setLocalNodeDeathTimeoutMillis(localNodeDeathTimeoutMillis);
+        return this;
+    }
+
+    public RedisClusterBuilder deadNodeCullingDelayMillis(final long deadNodeCullingDelayMillis) {
+        redisClusterConfig.setDeadNodeCullingDelayMillis(deadNodeCullingDelayMillis);
+        return this;
+    }
+
     public RedisClusterPeer build() {
         return new RedisClusterPeer(redisClusterConfig);
     }

--- a/src/main/java/cloud/orbit/actors/cluster/RedisClusterConfig.java
+++ b/src/main/java/cloud/orbit/actors/cluster/RedisClusterConfig.java
@@ -30,9 +30,8 @@ package cloud.orbit.actors.cluster;
 
 import cloud.orbit.actors.cluster.pipeline.RedisBasicPipeline;
 import cloud.orbit.actors.cluster.pipeline.RedisPipelineStep;
-import cloud.orbit.exception.UncheckedException;
+import cloud.orbit.actors.extensions.ActorClassFinder;
 
-import java.net.URI;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -44,6 +43,7 @@ import java.util.concurrent.ForkJoinPool;
  */
 public class RedisClusterConfig
 {
+    private ActorClassFinder actorClassFinder = null;
     private List<String> actorDirectoryUris = Arrays.asList("redis://localhost:6379");
     private List<String> nodeDirectoryUris = Arrays.asList("redis://localhost:6379");
     private List<String> messagingUris = Arrays.asList("redis://localhost:6379");
@@ -72,6 +72,21 @@ public class RedisClusterConfig
     private Integer redisPipelineFlushCommandCount = 16;
     private Boolean useElasticache = false;
     private Boolean useCluster = false;
+
+    private int minNodesInCluster = 1;
+    private long foreignNodeDeathTimeoutMillis = 20_000;
+    private long localNodeDeathTimeoutMillis = 10_000;
+    private long deadNodeCullingDelayMillis = 24 * 60 * 60 * 1_000; // 24 hours
+
+    public ActorClassFinder getActorClassFinder()
+    {
+        return actorClassFinder;
+    }
+
+    public void setActorClassFinder(final ActorClassFinder actorClassFinder)
+    {
+        this.actorClassFinder = actorClassFinder;
+    }
 
     public List<String> getActorDirectoryUris()
     {
@@ -357,4 +372,43 @@ public class RedisClusterConfig
         return this.useCluster;
     }
 
+    public int getMinNodesInCluster()
+    {
+        return minNodesInCluster;
+    }
+
+    public void setMinNodesInCluster(final int minNodesInCluster)
+    {
+        this.minNodesInCluster = minNodesInCluster;
+    }
+
+    public long getForeignNodeDeathTimeoutMillis()
+    {
+        return foreignNodeDeathTimeoutMillis;
+    }
+
+    public void setForeignNodeDeathTimeoutMillis(final long foreignNodeDeathTimeoutMillis)
+    {
+        this.foreignNodeDeathTimeoutMillis = foreignNodeDeathTimeoutMillis;
+    }
+
+    public long getLocalNodeDeathTimeoutMillis()
+    {
+        return localNodeDeathTimeoutMillis;
+    }
+
+    public void setLocalNodeDeathTimeoutMillis(final long localNodeDeathTimeoutMillis)
+    {
+        this.localNodeDeathTimeoutMillis = localNodeDeathTimeoutMillis;
+    }
+
+    public long getDeadNodeCullingDelayMillis()
+    {
+        return deadNodeCullingDelayMillis;
+    }
+
+    public void setDeadNodeCullingDelayMillis(final long deadNodeCullingDelayMillis)
+    {
+        this.deadNodeCullingDelayMillis = deadNodeCullingDelayMillis;
+    }
 }

--- a/src/main/java/cloud/orbit/actors/cluster/RedisClusterPeer.java
+++ b/src/main/java/cloud/orbit/actors/cluster/RedisClusterPeer.java
@@ -31,27 +31,38 @@ package cloud.orbit.actors.cluster;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import cloud.orbit.actors.Actor;
+import cloud.orbit.actors.NodeState;
+import cloud.orbit.actors.NodeType;
+import cloud.orbit.actors.cluster.heartbeat.RedisClusterHeartBeat;
 import cloud.orbit.actors.cluster.impl.RedisConnectionManager;
 import cloud.orbit.actors.cluster.impl.RedisKeyGenerator;
 import cloud.orbit.actors.cluster.impl.RedisMsg;
 import cloud.orbit.actors.cluster.impl.RedisShardedMap;
-
-import cloud.orbit.actors.cluster.impl.lettuce.LettuceClient;
+import cloud.orbit.actors.cluster.state.RedisClusterTracker;
 import cloud.orbit.concurrent.Task;
 import cloud.orbit.tuples.Pair;
 import io.lettuce.core.pubsub.RedisPubSubAdapter;
 import io.lettuce.core.pubsub.RedisPubSubListener;
 
-import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 /**
- * Created by joeh@ea.com on 2016-12-13.
+ * The <code>RedisClusterPeer</code> implements a <code>ClusterPeer</code> backed by Redis.
+ *
+ * Nodes communicate about the state of the cluster by periodically sending heartbeats to a shared pubsub topic.
+ * Heartbeats contain each node's own view of the cluster, as well as its own state. Updates that change the topology
+ * of the cluster (such as adding or losing nodes) are propagated up to Orbit's <code>Hosting</code> layer by the
+ * <code>ViewListener</code>.
+ *
+ * Messages between nodes are also sent over sharded pub-sub topics.
+ *
  */
 public class RedisClusterPeer implements ClusterPeer
 {
@@ -65,10 +76,22 @@ public class RedisClusterPeer implements ClusterPeer
 
     private final ConcurrentMap<String, ConcurrentMap<?, ?>> cacheManager = new ConcurrentHashMap<>();
 
+    private final RedisClusterTracker clusterTracker;
+
+    private volatile ClusterView latestClusterView;
+
 
     public RedisClusterPeer(final RedisClusterConfig config)
     {
         this.config = config;
+
+        final Collection<Class<? extends Actor>> actorInterfaces = config.getActorClassFinder().findActorInterfaces(p -> true);
+
+        final Set<String> hostableInterfaces = actorInterfaces.stream()
+                .map(Class::getName)
+                .collect(Collectors.toSet());
+
+        this.clusterTracker = new RedisClusterTracker(config, this.localAddress, hostableInterfaces);
     }
 
     @Override
@@ -96,30 +119,89 @@ public class RedisClusterPeer implements ClusterPeer
     }
 
     @Override
-    public Task<?> join(final String clusterName, final String nodeName)
+    public Task<?> join(final String clusterName, final String nodeName, final NodeType nodeType)
     {
         logger.info("Joining Redis Cluster '{}' as node '{}' [{}]...", clusterName, nodeName, localAddress.asUUID().toString());
+        this.clusterTracker.setNodeName(nodeName);
 
         this.clusterName = clusterName;
-        redisConnectionManager = new RedisConnectionManager(config);
+        this.redisConnectionManager = new RedisConnectionManager(config);
 
+        this.clusterTracker.setNodeState(NodeState.RUNNING);
+        this.clusterTracker.setNodeType(NodeType.CLIENT);
 
-        // Subscribe to Pub Sub
+        /*
+        Note: Because the `RedisConnectionManager` maintains a single list of `LettucePubSubClient`s to be used for all
+        messaging, both node->node messages and node->cluster heartbeats are multiplexed over the same underlying TCP/
+        Redis connection. Messages must therefore be discriminated by the `RedisPubSubListener` instance based on either
+        the channel or the message object type -- here, we have chosen to discriminate based on message type.
+         */
+
+        // Subscribe to Cluster-HeartBeat channel
+        final String clusterChannelKey = getClusterChannelKey(clusterName);
+        logger.info("Joining topic '{}'", clusterChannelKey);
+        redisConnectionManager.subscribeToChannel(clusterChannelKey, new RedisPubSubAdapter<String, Object>()
+        {
+            @Override
+            public void message(final String channel, final Object redisMsg)
+            {
+                if ( redisMsg instanceof RedisClusterHeartBeat )
+                {
+                    receiveHeartBeat((RedisClusterHeartBeat)redisMsg);
+                }
+            }
+        });
+
+        // Wait until the cluster agrees that this node is in the cluster.
+        while ( ! clusterTracker.isLocalNodeInCluster() && ! this.clusterTracker.isThisNodeDead() ) {
+            pulse();
+            sleep();
+        }
+
+        logger.info("Done joining the cluster as CLIENT");
+
+        // If required, upgrade ourselves to server mode and wait until the cluster agrees.
+        if ( nodeType == NodeType.SERVER ) {
+            logger.info("Upgrading from CLIENT to SERVER");
+
+            clusterTracker.setNodeType(NodeType.SERVER);
+            pulse();
+
+            logger.info("Done upgrading from CLIENT to SERVER");
+        }
+
+        // Subscribe to Orbit Messaging Pub Sub
+         logger.info("Subscribing to messages...");
         final String nodeKey = RedisKeyGenerator.nodeKey(clusterName, localAddress.toString());
         RedisPubSubListener<String, Object> listener = new RedisPubSubAdapter<String, Object>()
         {
             @Override
             public void message(String channel, Object redisMsg)
             {
-                receiveMessage((RedisMsg)redisMsg);
+                if ( redisMsg instanceof RedisMsg )
+                {
+                    receiveMessage((RedisMsg) redisMsg);
+                }
             }
         };
         redisConnectionManager.subscribeToChannel(nodeKey, listener);
 
+        logger.info("Done joining cluster!");
+        return Task.done();
+    }
 
-        writeMyEntry();
-        syncNodes();
+    private void sleep()
+    {
+        try
+        {
+            Thread.sleep(1000L);
+        } catch (InterruptedException ignored) {}
+    }
 
+    @Override
+    public Task<?> notifyStateChange(final NodeState newNodeState)
+    {
+        changeLocalNodeState(newNodeState);
         return Task.done();
     }
 
@@ -127,30 +209,39 @@ public class RedisClusterPeer implements ClusterPeer
         redisConnectionManager.refreshMessagingTopology(messagingUris);
     }
 
-    private void writeMyEntry()
-    {
-        final String nodeKey = RedisKeyGenerator.nodeKey(clusterName, localAddress.toString());
-        redisConnectionManager.getShardedNodeDirectoryClient(nodeKey).set(nodeKey, localAddress.toString(), TimeUnit.SECONDS.toMillis(config.getNodeLifetimeSeconds())).join();
+    private String getClusterChannelKey(final String clusterName) {
+        return RedisKeyGenerator.clusterKey(clusterName);
     }
 
-    private void syncNodes()
+    private void publishHeartBeat() {
+        final String clusterChannelKey = getClusterChannelKey(clusterName);
+        final RedisClusterHeartBeat heartBeat = clusterTracker.createHeartBeat();
+        redisConnectionManager.sendMessageToChannel(clusterChannelKey, heartBeat);
+    }
+
+    private void receiveHeartBeat(RedisClusterHeartBeat heartBeat) {
+        // Shift the work onto an Orbit (rather than Lettuce) thread.
+        Task.runAsync(() -> receiveHeartBeatInternal(heartBeat), config.getCoreExecutorService())
+                .exceptionally((e) ->
+                {
+                    logger.error("Error receiving heartbeat", e);
+                    return null;
+                });
+    }
+
+    private void receiveHeartBeatInternal ( final RedisClusterHeartBeat heartBeat )
     {
-        final String nodeKey = RedisKeyGenerator.nodeKey(clusterName, "*");
+        logger.trace("receiveHeartBeat {}", heartBeat);
 
-        List<String> keys = new ArrayList<>();
-        List<LettuceClient<String, Object>> clients = redisConnectionManager.getNodeDirectoryClients();
-        for (LettuceClient<String, Object> client : clients) {
-            keys.addAll(client.scan(nodeKey).join());
+        // Apply the new HeartBeat message to our internal state.
+        boolean clusterViewChanged = clusterTracker.receiveHeartBeat(heartBeat);
+
+        if ( clusterTracker.isLocalNodeInCluster() ) {
+            if ( clusterViewChanged )
+            {
+                pushNewClusterView();
+            }
         }
-
-        List<NodeAddress> nodeAddresses = new ArrayList<>();
-        for (final String key : keys)
-        {
-            final String rawKey = (String) redisConnectionManager.getShardedNodeDirectoryClient(key).get(key).join();
-            nodeAddresses.add(new NodeAddressImpl(UUID.fromString(rawKey)));
-        }
-
-        viewListener.onViewChange(nodeAddresses);
     }
 
     @Override
@@ -159,7 +250,6 @@ public class RedisClusterPeer implements ClusterPeer
         final RedisMsg redisMsg = new RedisMsg(localAddress.asUUID(), message);
         final String targetNodeKey = RedisKeyGenerator.nodeKey(clusterName, toAddress.toString());
         redisConnectionManager.sendMessageToChannel(targetNodeKey, redisMsg);
-
     }
 
     public void receiveMessage(final RedisMsg rawMessage)
@@ -181,17 +271,58 @@ public class RedisClusterPeer implements ClusterPeer
     @Override
     public Task pulse()
     {
-        writeMyEntry();
-        syncNodes();
+        final Set<NodeAddress> deadNodes = clusterTracker.scanForDeadNodes();
+
+        // If this node isn't hearing its own heartbeats, then it must be a zombie and must die immediately.
+        final boolean thisNodeIsDead = clusterTracker.isThisNodeDead();
+        if ( thisNodeIsDead ) {
+            logger.error("FATAL: Node {} detected itself as dead. Exiting to restart.", localAddress);
+            System.exit(-1);
+        }
+
+        // If we're alive, we can eventually forget about some long-dead nodes.
+        final boolean culledAnyNodes = clusterTracker.cullLongDeadNodes();
+
+        // Note: This ordering is important. We should only update the cluster view if this node isn't dead.
+        if ( ! deadNodes.isEmpty() ) {
+            logger.info("Detected dead nodes {}; updating view", deadNodes);
+            pushNewClusterView();
+        } else if ( culledAnyNodes ) {
+            logger.info("Culled some dead nodes; updating view");
+            pushNewClusterView();
+        }
+
+        publishHeartBeat();
+
         return Task.done();
+    }
+
+    private void pushNewClusterView()
+    {
+        final ClusterView clusterView = clusterTracker.createClusterView();
+        logger.info("ClusterView = {}", clusterView);
+        this.latestClusterView = clusterView;
+        viewListener.onViewChange(clusterView);
     }
 
     @Override
     public void leave()
     {
-        final String nodeKey = RedisKeyGenerator.nodeKey(clusterName, localAddress.toString());
-        redisConnectionManager.getShardedNodeDirectoryClient(nodeKey).del(nodeKey).join();
+        // Tell other nodes that this node has stopped
+        changeLocalNodeState(NodeState.STOPPED);
         redisConnectionManager.shutdownConnections();
+    }
+
+    private void changeLocalNodeState ( final NodeState newNodeState ) {
+        // Note: since changeLocalNodeState is only used for RUNNING -> STOPPING and STOPPING -> STOPPED changes, we
+        // don't wait for other nodes to agree here; we just wait to make sure that we've either (a) sent an updated
+        // heartbeat correctly, or (b) we have died and can just give up.
+        this.clusterTracker.setNodeState(newNodeState);
+        do
+        {
+            pulse();
+            sleep();
+        } while ( ! this.clusterTracker.isThisNodeInState(newNodeState) && ! this.clusterTracker.isThisNodeDead() );
     }
 
     @Override
@@ -204,5 +335,15 @@ public class RedisClusterPeer implements ClusterPeer
     public void registerViewListener(final ViewListener viewListener)
     {
         this.viewListener = viewListener;
+    }
+
+    public ClusterView getLatestClusterView()
+    {
+        return this.latestClusterView;
+    }
+
+    public RedisClusterTracker getClusterTracker()
+    {
+        return this.clusterTracker;
     }
 }

--- a/src/main/java/cloud/orbit/actors/cluster/heartbeat/RedisClusterHeartBeat.java
+++ b/src/main/java/cloud/orbit/actors/cluster/heartbeat/RedisClusterHeartBeat.java
@@ -1,0 +1,122 @@
+/*
+ Copyright (C) 2018 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package cloud.orbit.actors.cluster.heartbeat;
+
+import cloud.orbit.actors.NodeState;
+import cloud.orbit.actors.NodeType;
+import cloud.orbit.actors.cluster.NodeAddress;
+
+import java.io.Serializable;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A <code>RedisClusterHeartBeat</code> is the data type that gets sent over Redis Pub/Sub to allow nodes to share their
+ * local view of the cluster and (eventually) reach consensus about which nodes are in the cluster and in which mode.
+ *
+ * Received instances of this class are used to update a node's local <code>RedisClusterTracker</code>, which can also
+ * produce new instances of this class to send back out to the cluster.
+ */
+public class RedisClusterHeartBeat implements Serializable
+{
+    private final NodeAddress nodeAddress;
+    private final String nodeName; // human-friendly name, such as "hostname:port"
+
+    private final NodeType nodeType;
+    private final NodeState nodeState;
+
+    private final int sequenceNumber;
+    private final Set<String> hostableInterfaces;
+
+    private final Map<NodeAddress, RedisClusterNodeView> nodeViews;
+
+    public RedisClusterHeartBeat(
+            final NodeAddress nodeAddress,
+            final String nodeName,
+            final NodeType nodeType,
+            final NodeState nodeState,
+            final int sequenceNumber,
+            final Set<String> hostableInterfaces,
+            final Map<NodeAddress, RedisClusterNodeView> nodeViews)
+    {
+        this.nodeAddress = nodeAddress;
+        this.nodeName = nodeName;
+
+        this.nodeType = nodeType;
+        this.nodeState = nodeState;
+
+        this.sequenceNumber = sequenceNumber;
+        this.hostableInterfaces = hostableInterfaces;
+        this.nodeViews = nodeViews;
+    }
+
+    public NodeAddress getNodeAddress()
+    {
+        return nodeAddress;
+    }
+
+    public String getNodeName()
+    {
+        return nodeName;
+    }
+
+    public NodeType getNodeType()
+    {
+        return nodeType;
+    }
+
+    public NodeState getNodeState()
+    {
+        return nodeState;
+    }
+
+    public int getSequenceNumber()
+    {
+        return sequenceNumber;
+    }
+
+    public Set<String> getHostableInterfaces()
+    {
+        return hostableInterfaces;
+    }
+
+    public Map<NodeAddress, RedisClusterNodeView> getNodeViews()
+    {
+        return nodeViews;
+    }
+
+    @Override
+    public String toString()
+    {
+        StringBuilder buf = new StringBuilder("RedisClusterHeartBeat ");
+        buf.append(" ").append(nodeAddress).append(" ").append(nodeName).append(" ").append(nodeState).append(" ").append(nodeType).append('\n');
+        nodeViews.forEach((addr, view) -> buf.append('\t').append(addr).append(' ').append(view).append('\n'));
+        return buf.toString();
+    }
+}

--- a/src/main/java/cloud/orbit/actors/cluster/heartbeat/RedisClusterNodeView.java
+++ b/src/main/java/cloud/orbit/actors/cluster/heartbeat/RedisClusterNodeView.java
@@ -1,0 +1,115 @@
+/*
+ Copyright (C) 2018 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package cloud.orbit.actors.cluster.heartbeat;
+
+import cloud.orbit.actors.NodeType;
+import cloud.orbit.actors.NodeState;
+import cloud.orbit.actors.cluster.NodeAddress;
+
+import java.io.Serializable;
+
+/**
+ * A <code>RedisClusterNodeView</code> is an immutable snapshot of a single node's "view" of another node as published
+ * in a <code>RedisClusterHeartBeat</code>. See also related class <code>RedisClusterNodeTracker</code>, which is the
+ * mutable tracker version of this class.
+ */
+public class RedisClusterNodeView implements Serializable
+{
+    private final NodeAddress nodeAddress;
+    private final NodeType nodeType;
+    private final NodeState nodeState;
+
+    // Not-strictly-necessary stats values:
+    private final long lastReceivedTimestamp; // is this timeout from the source node, or is it recorded on the dest node? if we're comparing to the dest node's clock, then it should be pulled from the dest node's clock too
+    private final int lastReceivedSequenceNumber;
+
+    private final int missedSequenceNumbersCount; // a 'missed' seqnum is between two received heartbeats. if you get 5, then get 8, then missedSequenceNumbersCount += 2;
+    private final int longestMissedSequenceNumberStreak;
+
+    public RedisClusterNodeView(
+            final NodeAddress nodeAddress,
+            final NodeType nodeType,
+            final NodeState nodeState,
+            final long lastReceivedTimestamp,
+            final int lastReceivedSequenceNumber,
+            final int missedSequenceNumbersCount,
+            final int longestMissedSequenceNumberStreak
+    )
+    {
+        this.nodeAddress = nodeAddress;
+        this.nodeType = nodeType;
+        this.nodeState = nodeState;
+        this.lastReceivedTimestamp = lastReceivedTimestamp;
+        this.lastReceivedSequenceNumber = lastReceivedSequenceNumber;
+        this.missedSequenceNumbersCount = missedSequenceNumbersCount;
+        this.longestMissedSequenceNumberStreak = longestMissedSequenceNumberStreak;
+    }
+
+    public NodeAddress getNodeAddress()
+    {
+        return nodeAddress;
+    }
+
+    public NodeType getNodeType()
+    {
+        return nodeType;
+    }
+
+    public NodeState getNodeState()
+    {
+        return nodeState;
+    }
+
+    public long getLastReceivedTimestamp()
+    {
+        return lastReceivedTimestamp;
+    }
+
+    public int getLastReceivedSequenceNumber()
+    {
+        return lastReceivedSequenceNumber;
+    }
+
+    public int getMissedSequenceNumbersCount()
+    {
+        return missedSequenceNumbersCount;
+    }
+
+    public int getLongestMissedSequenceNumberStreak()
+    {
+        return longestMissedSequenceNumberStreak;
+    }
+
+    @Override
+    public String toString()
+    {
+        long now = System.currentTimeMillis();
+        return nodeState + " " + nodeType + " (" + (now - lastReceivedTimestamp) + "ms ago)";
+    }
+}

--- a/src/main/java/cloud/orbit/actors/cluster/impl/lettuce/LettucePubSubClient.java
+++ b/src/main/java/cloud/orbit/actors/cluster/impl/lettuce/LettucePubSubClient.java
@@ -150,7 +150,7 @@ public class LettucePubSubClient
         }
     }
 
-    private void flush() {
+    public void flush() {
         redisPublishingAsyncCommands.flushCommands();
         flushed.set(true);
     }

--- a/src/main/java/cloud/orbit/actors/cluster/state/RedisClusterNodeTracker.java
+++ b/src/main/java/cloud/orbit/actors/cluster/state/RedisClusterNodeTracker.java
@@ -1,0 +1,182 @@
+/*
+ Copyright (C) 2018 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package cloud.orbit.actors.cluster.state;
+
+import cloud.orbit.actors.NodeState;
+import cloud.orbit.actors.NodeType;
+import cloud.orbit.actors.cluster.ClusterNodeView;
+import cloud.orbit.actors.cluster.NodeAddress;
+import cloud.orbit.actors.cluster.heartbeat.RedisClusterHeartBeat;
+import cloud.orbit.actors.cluster.heartbeat.RedisClusterNodeView;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * A <code>RedisClusterNodeTracker</code> is a mutable tracker that represents Node A's view of Node B and of Node B's
+ * view of the cluster.
+ */
+public class RedisClusterNodeTracker
+{
+    private final NodeAddress nodeAddress;
+
+    private String nodeName;
+    private NodeType nodeType;
+    private NodeState nodeState;
+    private Set<String> hostableActorInterfaces;
+
+
+    private long lastHeartBeatLocalTimestamp = -1;
+    private int lastHeartBeatSequenceNumber = -1;
+
+
+    private int missedSequenceNumberCount = 0;
+    private int longestMissedSequenceNumberStreak = 0;
+
+    private Map<NodeAddress, RedisClusterNodeView> nodeViews;
+
+
+    public RedisClusterNodeTracker(final NodeAddress nodeAddress)
+    {
+        this.nodeAddress = nodeAddress;
+    }
+
+    public synchronized boolean receiveHeartBeat(final RedisClusterHeartBeat heartBeat) {
+        // Discard any out-of-order heartbeats
+        if ( heartBeat.getSequenceNumber() <= this.lastHeartBeatSequenceNumber ) {
+            return false;
+        }
+
+        this.lastHeartBeatLocalTimestamp = System.currentTimeMillis();
+
+        if ( this.lastHeartBeatSequenceNumber >= 0 )
+        {
+            int expectedSequenceNumber = this.lastHeartBeatSequenceNumber + 1;
+            int missedSequenceNumbers = heartBeat.getSequenceNumber() - expectedSequenceNumber;
+            this.missedSequenceNumberCount += missedSequenceNumbers;
+            this.longestMissedSequenceNumberStreak = Math.max(this.longestMissedSequenceNumberStreak, missedSequenceNumbers);
+        }
+
+        this.lastHeartBeatSequenceNumber = heartBeat.getSequenceNumber();
+
+        // The view is updated if (a) any node transitions CLIENT -> HOST, (b) any note transitions state, (c) any node
+        // changes its advertised set of hostable actors. The cluster view is not sensitive to other node's cluster views.
+        final boolean isViewUpdated = ! Objects.equals(this.nodeType, heartBeat.getNodeType())
+                || ! Objects.equals(this.nodeState, heartBeat.getNodeState())
+                || ! Objects.equals(this.hostableActorInterfaces, heartBeat.getHostableInterfaces());
+
+        this.nodeName = heartBeat.getNodeName();
+        this.nodeType = heartBeat.getNodeType();
+        this.nodeState = heartBeat.getNodeState();
+        this.hostableActorInterfaces = heartBeat.getHostableInterfaces();
+        this.nodeViews = heartBeat.getNodeViews();
+
+        return isViewUpdated;
+    }
+
+    public RedisClusterNodeView createHeartBeatClusterNodeView()
+    {
+        return new RedisClusterNodeView(
+                this.nodeAddress,
+                this.nodeType,
+                this.nodeState,
+                this.lastHeartBeatLocalTimestamp,
+                this.lastHeartBeatSequenceNumber,
+                this.missedSequenceNumberCount,
+                this.longestMissedSequenceNumberStreak
+        );
+    }
+
+    public ClusterNodeView createClusterNodeView()
+    {
+        return new ClusterNodeView(
+                this.nodeAddress,
+                this.nodeName,
+                this.nodeType,
+                this.nodeState,
+                this.hostableActorInterfaces
+        );
+    }
+
+    public NodeAddress getNodeAddress()
+    {
+        return nodeAddress;
+    }
+
+    public String getNodeName()
+    {
+        return nodeName;
+    }
+
+    public NodeType getNodeType()
+    {
+        return nodeType;
+    }
+
+    public NodeState getNodeState()
+    {
+        return nodeState;
+    }
+
+    public void setNodeState(final NodeState nodeState)
+    {
+        this.nodeState = nodeState;
+    }
+
+    public Set<String> getHostableActorInterfaces()
+    {
+        return hostableActorInterfaces;
+    }
+
+    public long getLastHeartBeatLocalTimestamp()
+    {
+        return lastHeartBeatLocalTimestamp;
+    }
+
+    public int getLastHeartBeatSequenceNumber()
+    {
+        return lastHeartBeatSequenceNumber;
+    }
+
+    public int getMissedSequenceNumberCount()
+    {
+        return missedSequenceNumberCount;
+    }
+
+    public int getLongestMissedSequenceNumberStreak()
+    {
+        return longestMissedSequenceNumberStreak;
+    }
+
+    public Map<NodeAddress, RedisClusterNodeView> getNodeViews()
+    {
+        return nodeViews;
+    }
+}

--- a/src/main/java/cloud/orbit/actors/cluster/state/RedisClusterTracker.java
+++ b/src/main/java/cloud/orbit/actors/cluster/state/RedisClusterTracker.java
@@ -1,0 +1,269 @@
+/*
+ Copyright (C) 2018 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package cloud.orbit.actors.cluster.state;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import cloud.orbit.actors.NodeState;
+import cloud.orbit.actors.NodeType;
+import cloud.orbit.actors.cluster.ClusterNodeView;
+import cloud.orbit.actors.cluster.ClusterView;
+import cloud.orbit.actors.cluster.NodeAddress;
+import cloud.orbit.actors.cluster.RedisClusterConfig;
+import cloud.orbit.actors.cluster.heartbeat.RedisClusterHeartBeat;
+import cloud.orbit.actors.cluster.heartbeat.RedisClusterNodeView;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Function;
+
+import static java.util.Collections.emptySet;
+import static java.util.stream.Collectors.toMap;
+
+/**
+ * A <code>RedisClusterTracker</code> is responsible for tracking the state of the cluster, as perceived by the local
+ * node, as updated by <code>RedisClusterHeartBeat</code>s received over Redis.
+ */
+public class RedisClusterTracker
+{
+    private static Logger logger = LoggerFactory.getLogger(RedisClusterTracker.class);
+
+    private final RedisClusterConfig config;
+    private final NodeAddress localAddress;
+    private final Set<String> hostableInterfaces;
+
+    private String nodeName; // human-friendly node name supplied by the application layer via config, such as "hostname:port"
+    private volatile NodeType nodeType; // note: only valid transition for this field is CLIENT -> HOST.
+    private volatile NodeState nodeState; // note: valid transitions are RUNNING -> STOPPING -> STOPPED and RUNNING -> PRESUMED_DEAD
+
+    private volatile int sequenceNumber = 0;
+
+    // field contents updated by heartbeats
+    // note: contains a mapping for `localAddress` -> our own heartbeats
+    private final ConcurrentMap<NodeAddress, RedisClusterNodeTracker> nodeTrackers = new ConcurrentHashMap<>();
+
+
+    public RedisClusterTracker(final RedisClusterConfig config, final NodeAddress localAddress, final Set<String> hostableInterfaces)
+    {
+        this.config = config;
+        this.localAddress = localAddress;
+        this.hostableInterfaces = hostableInterfaces;
+    }
+
+    public RedisClusterHeartBeat createHeartBeat () {
+        ++sequenceNumber;
+
+        final Map<NodeAddress, RedisClusterNodeView> snapshotNodeViews = nodeTrackers.values().stream()
+                .map(RedisClusterNodeTracker::createHeartBeatClusterNodeView)
+                .collect(toMap(RedisClusterNodeView::getNodeAddress, Function.identity()));
+
+        return new RedisClusterHeartBeat(
+                this.localAddress,
+                this.nodeName,
+                this.nodeType,
+                this.nodeState,
+                this.sequenceNumber,
+                this.hostableInterfaces,
+                snapshotNodeViews
+        );
+    }
+
+    public boolean receiveHeartBeat(final RedisClusterHeartBeat heartBeat)
+    {
+        final RedisClusterNodeTracker tracker = this.nodeTrackers.computeIfAbsent(heartBeat.getNodeAddress(), RedisClusterNodeTracker::new);
+        return tracker.receiveHeartBeat(heartBeat);
+    }
+
+    public ClusterView createClusterView()
+    {
+        final SortedMap<NodeAddress, ClusterNodeView> sortedNodes = new TreeMap<>();
+
+        nodeTrackers.values().stream()
+                .map(RedisClusterNodeTracker::createClusterNodeView)
+                .forEach(view -> sortedNodes.put(view.getNodeAddress(), view));
+
+        return new ClusterView(sortedNodes);
+    }
+
+    public Set<NodeAddress> scanForDeadNodes ()
+    {
+        final long foreignNodeDeathTimeout = config.getForeignNodeDeathTimeoutMillis();
+        final long localNodeDeathTimeout = config.getLocalNodeDeathTimeoutMillis();
+
+        Set<NodeAddress> deadNodes = null;
+
+        final long now = System.currentTimeMillis();
+        for ( RedisClusterNodeTracker tracker : this.nodeTrackers.values() )
+        {
+            final long timeout = Objects.equals(tracker.getNodeAddress(), this.localAddress) ? localNodeDeathTimeout : foreignNodeDeathTimeout;
+            final long timeoutTimestamp = tracker.getLastHeartBeatLocalTimestamp() + timeout;
+            if ( now > timeoutTimestamp && tracker.getNodeState() == NodeState.RUNNING ) {
+                tracker.setNodeState(NodeState.PRESUMED_DEAD);
+
+                if ( deadNodes == null ) deadNodes = new HashSet<>();
+                deadNodes.add(tracker.getNodeAddress());
+            }
+        }
+
+        return deadNodes == null ? emptySet() : deadNodes;
+    }
+
+    public boolean cullLongDeadNodes ()
+    {
+        final long cullingTimeout = config.getDeadNodeCullingDelayMillis();
+        final long now = System.currentTimeMillis();
+        final long cullingThreshold = now - cullingTimeout;
+
+        return this.nodeTrackers.values().removeIf(tracker -> tracker.getLastHeartBeatLocalTimestamp() < cullingThreshold);
+    }
+
+    /** Note: only works after calling scanForDeadNodes 'recently' (timeout-based) */
+    public boolean isThisNodeDead()
+    {
+        return isThisNodeInState(NodeState.PRESUMED_DEAD);
+    }
+
+    public boolean isThisNodeInState(final NodeState nodeState)
+    {
+        final RedisClusterNodeTracker selfTracker = nodeTrackers.get(this.localAddress);
+        return selfTracker != null && selfTracker.getNodeState() == nodeState;
+    }
+
+    public boolean isLocalNodeInCluster()
+    {
+        // Two conditions:
+        // - we have heartbeats from 'enough' nodes (enough = config value)
+        // - we take the set of all living nodes listed by all systems we have heartbeats from, then make sure that we
+        //   have a heartbeat from ALL of those nodes that agree that we are in the cluster...
+        return haveEnoughLivingNodesForAgreement() && clusterAgreesThatLocalIs(NodeState.RUNNING, null);
+    }
+
+    private boolean haveEnoughLivingNodesForAgreement () {
+        final long livingNodeCount = nodeTrackers.values().stream()
+                .filter(tracker -> tracker.getNodeState() == NodeState.RUNNING)
+                .count();
+
+        return livingNodeCount >= config.getMinNodesInCluster();
+    }
+
+
+    private boolean clusterAgreesThatLocalIs ( final NodeState requiredNodeState, final NodeType requiredNodeType ) {
+        // Note: the same 'rumouredNodeAddress' will occur repeatedly -- once in each nodeTracker.
+        // An alternative approach here would be to extract all rumouredNodeAddresses into a Set<NodeAddress>, then
+        // run through and check each of those once instead of many times. However, that requires allocating a HashSet,
+        // so I assume that this will be faster.
+        for ( final RedisClusterNodeTracker tracker : nodeTrackers.values() ) {
+            if ( tracker.getNodeState() != NodeState.RUNNING ) {
+                continue;
+            }
+
+            for ( final RedisClusterNodeView view : tracker.getNodeViews().values() ) {
+                // Ignore any rumoured nodes that aren't believed to be RUNNING.
+                if ( view.getNodeState() != NodeState.RUNNING ) {
+                    continue;
+                }
+
+                final NodeAddress rumouredNodeAddress = view.getNodeAddress();
+                final RedisClusterNodeTracker rumouredNodeTracker = nodeTrackers.get(rumouredNodeAddress);
+
+                // Some node (B) that we (A) have heard from knows of a different node (C) that we (A) haven't heard from.
+                if ( rumouredNodeTracker == null )
+                {
+                    logger.debug("clusterAgreesThatLocalIs {} {} -> FALSE because we have no record of {}", requiredNodeState, requiredNodeType, rumouredNodeAddress);
+                    return false;
+                }
+
+                // How does node C see us? If C doesn't report seeing us yet, or doesn't see us with the required
+                // nodeState / nodeType, then we aren't officially in that state yet.
+                final RedisClusterNodeView viewOfLocal = rumouredNodeTracker.getNodeViews().get(localAddress);
+                if ( viewOfLocal == null )
+                {
+                    logger.debug("clusterAgreesThatLocalIs {} {} -> FALSE because {} does not see us", requiredNodeState, requiredNodeType, rumouredNodeAddress);
+                    return false;
+                }
+
+                if ( requiredNodeState != null && viewOfLocal.getNodeState() != requiredNodeState )
+                {
+                    logger.debug("clusterAgreesThatLocalIs {} {} -> FALSE because {} sees us as {}", requiredNodeState, requiredNodeType, rumouredNodeAddress, viewOfLocal.getNodeState());
+                    return false;
+                }
+
+                if ( requiredNodeType != null && viewOfLocal.getNodeType() != requiredNodeType )
+                {
+                    logger.debug("clusterAgreesThatLocalIs {} {} -> FALSE because {} sees us as {}", requiredNodeState, requiredNodeType, rumouredNodeAddress, viewOfLocal.getNodeType());
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    public String getNodeName()
+    {
+        return nodeName;
+    }
+
+    public void setNodeName(final String nodeName)
+    {
+        this.nodeName = nodeName;
+    }
+
+    public NodeType getNodeType()
+    {
+        return nodeType;
+    }
+
+    public void setNodeType(final NodeType nodeType)
+    {
+        this.nodeType = nodeType;
+    }
+
+    public NodeState getNodeState()
+    {
+        return nodeState;
+    }
+
+    public void setNodeState(final NodeState nodeState)
+    {
+        this.nodeState = nodeState;
+    }
+
+    public ConcurrentMap<NodeAddress, RedisClusterNodeTracker> getNodeTrackers()
+    {
+        return nodeTrackers;
+    }
+}


### PR DESCRIPTION
Significantly alter clustering algorithm to resolve issues with Orbit incorrectly causing multiple activations of the same actor in a single cluster. These issues were specifically observed using the orbit-redis-cluster plugin, not the builtin JGroupsClusterPeer.

Old cluster algorithm has nodes joining a cluster by announcing that they are members and the immediately proceeding without waiting for agreement from other nodes. This is bad because two nodes in the “same” cluster might not ‘see’ each other for several seconds. During this time, they will assume that any actor directory entries for the other node are defunct and will replace them, causing the multiple-activation issue above.

The old implementation also had the `Hosting` (aka `NodeCapabilities`) layer implement queries between nodes about which actors are supported where. The new implementation pushes those details down into the `ClusterPeer` implementation, which can then be simply based on a heartbeat-type algorithm.

Now the `ClusterPeer` is responsible for making up-to-date `ClusterView` implementations available to the `Hosting` layer, which uses that `ClusterView` to perform its duties, including checking the `ActorDirectory` entries as appropriate.

New cluster algorithm is as follows:

1. Nodes periodically (on Stage.pulse) issue a heartbeat that contains a summary of their own ‘view’ of the cluster.
2. Nodes joining the cluster in CLIENT mode must wait until they have enough other nodes for consensus (config setting), and all known nodes agree that this new node is in the cluster.
3. Nodes joining the cluster in SERVER mode first join as a CLIENT, then instantaneously upgrade themselves to SERVER mode.
4. Nodes which do not receive their own heartbeat within (localNodeDeathTimeout, default 10s) will consider themselves dead and go for restart. Since we run within Docker or some other auto-restarting container, this is simply `System.exit(-1)` for now.
5. Nodes which do not receive another node's heartbeat within (foreignNodeDeathTimeout, default 20s) will consider that node to be dead.