### PR TITLE
Fix: Potential deadlock inside Shutdown.java when connection is lost to Redis.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,11 +39,11 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
     <groupId>cloud.orbit</groupId>
     <artifactId>orbit-redis-cluster</artifactId>
-    <version>1.3.1.0-SNAPSHOT</version>
+    <version>1.3.1.1-SNAPSHOT</version>
     <name>Orbit Redis Cluster</name>
 
     <properties>
-        <orbit.version>1.10.3.0-SNAPSHOT</orbit.version>
+        <orbit.version>1.10.3.1-SNAPSHOT</orbit.version>
     </properties>
 
     <scm>


### PR DESCRIPTION
Inside of the orbit stage, when we call `pulse` on the clusterPeer, we are asking the `ForkJoin CommonPool` to attempt to publish a heartbeat to our tracked cluster. Should we lose our connection to Redis, the next `pulse` request will have every common pool worker thread call System.Exit(-1). Because the `exit` method in lang/Shutdown.Java is synchronized on the class, only one thread will hold that monitor and the rest will wait. Because the jvm is dying, more often than not, applications using this library will want to request that the orbit stage shuts itself down. On attempting to call shut down on the orbit stage, we call pulse one more time which results in the executing thread also calling System.Exit and at that point you have now dead locked as the thread currently holding the monitor inside Shutdown.Java is waiting for the thread that is shutting down the orbit stage.

The dead-lock trigger inside of orbit:
Inside Stage::doStop
`await(hosting.notifyStateChange().whenCompleteAsync((r, e) -> {}, shutdownExecutor));`

which will call:
`changeLocalNodeState` which will then call `pulse()`
Hence why in RedisClusterPeer.Java you will notice that we check if we have lost connection to the cluster before executing our `pulse()`. 

Other Changes:
Also changed the version of orbit that we are using to our most recent version.

We should probably re-think the following...
1. In Orbit, do we need to have a thread pool execute pulse? Could we not just have one thread pulse if it is done so frequently?
2. Is there a way we can gracefully shut down our application should we lose connectivity to Redis?
